### PR TITLE
ci: テストファイルのコードスタイルチェック設定を更新

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,11 @@
     <!-- PSR-12 を適用 -->
     <rule ref="PSR12"/>
 
+    <!-- テストの長い行を許可 -->
+    <rule ref="Generic.Files.LineLength">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
     <!-- 対象ディレクトリを指定 -->
     <file>src</file>
     <file>config</file>


### PR DESCRIPTION
## 概要

テストファイルでの行長チェックを除外するためにphpcs.xmlの設定を更新しました。

## 変更内容

- phpcs.xmlにテストファイルに対する行長チェック除外設定を追加
- テストファイルでの長いメソッド名やアサーション文に対する制限を緩和

## 理由

テストファイルでは、テストメソッド名や長いアサーション文などで行長が長くなることが多く、可読性を保つためにこれらのチェックを除外する必要があったため。

## 確認方法

```bash
composer test
composer cs-check
```

これらのコマンドが正常に実行されることを確認してください。