### PR TITLE
docs: centralize CSS styles for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,47 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Index of /</title>
-    <style>
-        body {
-            background-color: #ffffff;
-            color: #000000;
-            font-family: monospace;
-            margin: 0;
-            padding: 0;
-        }
-
-        h1 {
-            margin: 0.5em;
-        }
-
-        hr {
-            margin: 0.5em 0;
-        }
-
-        pre {
-            margin: 0.5em 1em;
-            font-family: monospace;
-        }
-
-        a {
-            text-decoration: none;
-            color: #0000EE;
-        }
-
-        a:hover {
-            text-decoration: underline;
-        }
-
-        .header-line {
-            border-bottom: 1px solid #ccc;
-            margin-bottom: 0.5em;
-        }
-
-        .footer-line {
-            border-top: 1px solid #ccc;
-            margin-top: 0.5em;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
 <h1>Index of /</h1>

--- a/docs/json/index.html
+++ b/docs/json/index.html
@@ -3,47 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Index of /json</title>
-    <style>
-        body {
-            background-color: #ffffff;
-            color: #000000;
-            font-family: monospace;
-            margin: 0;
-            padding: 0;
-        }
-
-        h1 {
-            margin: 0.5em;
-        }
-
-        hr {
-            margin: 0.5em 0;
-        }
-
-        pre {
-            margin: 0.5em 1em;
-            font-family: monospace;
-        }
-
-        a {
-            text-decoration: none;
-            color: #0000EE;
-        }
-
-        a:hover {
-            text-decoration: underline;
-        }
-
-        .header-line {
-            border-bottom: 1px solid #ccc;
-            margin-bottom: 0.5em;
-        }
-
-        .footer-line {
-            border-top: 1px solid #ccc;
-            margin-top: 0.5em;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
 <body>
 <h1>Index of /json</h1>

--- a/docs/rss/index.html
+++ b/docs/rss/index.html
@@ -3,47 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Index of /rss</title>
-    <style>
-        body {
-            background-color: #ffffff;
-            color: #000000;
-            font-family: monospace;
-            margin: 0;
-            padding: 0;
-        }
-
-        h1 {
-            margin: 0.5em;
-        }
-
-        hr {
-            margin: 0.5em 0;
-        }
-
-        pre {
-            margin: 0.5em 1em;
-            font-family: monospace;
-        }
-
-        a {
-            text-decoration: none;
-            color: #0000EE;
-        }
-
-        a:hover {
-            text-decoration: underline;
-        }
-
-        .header-line {
-            border-bottom: 1px solid #ccc;
-            margin-bottom: 0.5em;
-        }
-
-        .footer-line {
-            border-top: 1px solid #ccc;
-            margin-top: 0.5em;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
 <body>
 <h1>Index of /rss</h1>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,39 @@
+body {
+    background-color: #ffffff;
+    color: #000000;
+    font-family: monospace;
+    margin: 0;
+    padding: 0;
+}
+
+h1 {
+    margin: 0.5em;
+}
+
+hr {
+    margin: 0.5em 0;
+}
+
+pre {
+    margin: 0.5em 1em;
+    font-family: monospace;
+}
+
+a {
+    text-decoration: none;
+    color: #0000EE;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.header-line {
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 0.5em;
+}
+
+.footer-line {
+    border-top: 1px solid #ccc;
+    margin-top: 0.5em;
+}


### PR DESCRIPTION
## Summary
- Extract common CSS styles from inline styles in HTML files to a shared CSS file
- Improve maintainability by centralizing styling across all documentation pages

## Changes Made
- Create `docs/style.css` with shared styles extracted from HTML files
- Update `docs/index.html` to use external CSS file
- Update `docs/json/index.html` to use external CSS file with relative path
- Update `docs/rss/index.html` to use external CSS file with relative path

## Benefits
- Eliminates code duplication across HTML files
- Improves maintainability - CSS changes only need to be made in one place
- Follows best practices for web development

## Test Plan
- [ ] Verify that all pages still display correctly after the changes
- [ ] Check that the external CSS file is properly loaded on all pages
- [ ] Ensure relative paths work correctly for subdirectory pages

🤖 Generated with [Claude Code](https://claude.ai/code)